### PR TITLE
19857-header action focus

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        uses: github/codeql-action/init@d6bbdef45e766d081b84a2def353b0055f728d3e # v3.29.3
         with:
           languages: javascript-typescript
           config: |
@@ -32,4 +32,4 @@ jobs:
               - 'packages/cli/src/component/templates/**'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        uses: github/codeql-action/analyze@d6bbdef45e766d081b84a2def353b0055f728d3e # v3.29.3

--- a/.github/workflows/publish-web-components-cdn-v2.yml
+++ b/.github/workflows/publish-web-components-cdn-v2.yml
@@ -1,0 +1,76 @@
+name: Publish Web Components CDN artifacts to Cloud Object Storage
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      # Matches tags that have the shape `vX.Y.Z` or `vX.Y.Z-rc.X` Reference:
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - '!v10*'
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-cdn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: '0'
+
+      - name: Use Node.js version from .nvmrc
+        uses: actions/setup-node@7e24a656e1c7a0d6f3eaef8d8e84ae379a5b035b
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: |
+          yarn install
+          yarn build
+
+      - name: Check release type
+        if: contains(github.ref_name, '-rc.')
+        run: echo "PRE_RELEASE=true" >> $GITHUB_ENV
+
+      - name: Get version of web components from package.json
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+        with:
+          path: packages/web-components
+
+      - name: Configure IBM Cloud credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.1
+        with:
+          aws-access-key-id: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.COMMON_COS_REGION }}
+
+      - name: Upload CDN artifacts
+        run: |
+          upload() {
+            local DEST=$1
+            echo "Uploading to $DEST"
+            aws s3 sync packages/web-components/dist \
+              s3://${{ secrets.COMMON_COS_BUCKET }}/$DEST \
+              --acl public-read \
+              --follow-symlinks \
+              --endpoint-url https://${{ secrets.COMMON_COS_ENDPOINT }}
+          }
+        
+          if [ "$PRE_RELEASE" = "true" ]; then
+            # If tag is a release candidate, upload the CDN artifacts to the `next` tag folder
+            # ie. https://1.www.s81c.com/common/carbon/web-components/tag/v2/next/breadcrumb.min.js
+            upload "common/carbon/web-components/tag/v2/next"
+          else
+            # If tag is a full release, upload the CDN artifacts to the `latest` tag folder
+            # ie. https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/breadcrumb.min.js
+            upload "common/carbon/web-components/tag/v2/latest"
+          fi
+
+          # Upload the CDN artifacts to versioned folder
+          # ie. https://1.www.s81c.com/common/carbon/web-components/version/v2.12.0/breadcrumb.min.js
+          upload "common/carbon/web-components/version/v${{ steps.package-version.outputs.current-version }}"

--- a/packages/react/src/components/TreeView/TreeContext.ts
+++ b/packages/react/src/components/TreeView/TreeContext.ts
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createContext, type SyntheticEvent, type MouseEvent } from 'react';
+import { createContext } from 'react';
 import type { TreeNodeProps } from './TreeNode';
 
 interface TreeContextProps {
   active?: string | number;
   multiselect?: boolean;
   onActivate?: (nodeId?: string | number) => void;
-  onTreeSelect?: (event: MouseEvent, node?: Partial<TreeNodeProps>) => void;
+  onTreeSelect?: TreeNodeProps['onTreeSelect'];
   selected?: Array<string | number>;
   size?: 'xs' | 'sm';
 }

--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -28,6 +28,13 @@ import { useFeatureFlag } from '../FeatureFlags';
 import { IconButton } from '../IconButton';
 import { TreeContext, DepthContext } from './TreeContext';
 
+type UncontrolledOnToggle = (
+  event: React.MouseEvent | React.KeyboardEvent,
+  node: Pick<TreeNodeProps, 'id' | 'label' | 'value' | 'isExpanded'>
+) => void;
+
+type ControlledOnToggle = (isExpanded: TreeNodeProps['isExpanded']) => void;
+
 export type TreeNodeProps = {
   /**
    * **Note:** this is controlled by the parent TreeView component, do not set manually.
@@ -76,20 +83,20 @@ export type TreeNodeProps = {
    * Callback function for when the node is selected
    */
   onSelect?: (
-    event: React.MouseEvent,
-    node?: Omit<TreeNodeProps, 'children'>
+    event: React.MouseEvent | React.KeyboardEvent,
+    node: Pick<TreeNodeProps, 'id' | 'label' | 'value'>
   ) => void;
   /**
    * Callback function for when a parent node is expanded or collapsed
    */
-  onToggle?: (
-    event: React.MouseEvent | React.KeyboardEvent,
-    node?: Omit<TreeNodeProps, 'children'>
-  ) => void;
+  onToggle?: UncontrolledOnToggle | ControlledOnToggle;
   /**
    * Callback function for when any node in the tree is selected
    */
-  onTreeSelect?: (event: React.MouseEvent, node?: TreeNodeProps) => void;
+  onTreeSelect?: (
+    event: React.MouseEvent | React.KeyboardEvent,
+    node: Pick<TreeNodeProps, 'id' | 'label' | 'value'>
+  ) => void;
   /**
    * A component used to render an icon.
    */
@@ -274,14 +281,7 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
 
     const controllableExpandedState = useControllableState({
       value: isExpanded,
-      onChange: (newValue: boolean) => {
-        onToggle?.(undefined as unknown as MouseEvent, {
-          id,
-          isExpanded: newValue,
-          label,
-          value,
-        });
-      },
+      onChange: onToggle as ControlledOnToggle,
       defaultValue: defaultIsExpanded ?? false,
     });
     const uncontrollableExpandedState = useState(isExpanded ?? false);
@@ -360,7 +360,12 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
       }
 
       if (!enableTreeviewControllable) {
-        onToggle?.(event, { id, isExpanded: !expanded, label, value });
+        (onToggle as UncontrolledOnToggle)?.(event, {
+          id,
+          isExpanded: !expanded,
+          label,
+          value,
+        });
       }
       setExpanded(!expanded);
     }
@@ -406,7 +411,12 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
 
         if (children && expanded) {
           if (!enableTreeviewControllable) {
-            onToggle?.(event, { id, isExpanded: false, label, value });
+            (onToggle as UncontrolledOnToggle)?.(event, {
+              id,
+              isExpanded: false,
+              label,
+              value,
+            });
           }
           setExpanded(false);
         } else {
@@ -438,7 +448,12 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
           )?.focus();
         } else {
           if (!enableTreeviewControllable) {
-            onToggle?.(event, { id, isExpanded: true, label, value });
+            (onToggle as UncontrolledOnToggle)?.(event, {
+              id,
+              isExpanded: true,
+              label,
+              value,
+            });
           }
           setExpanded(true);
         }
@@ -449,7 +464,12 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
         if (match(event, keys.Enter) && children) {
           // Toggle expansion state for parent nodes
           if (!enableTreeviewControllable) {
-            onToggle?.(event, { id, isExpanded: !expanded, label, value });
+            (onToggle as UncontrolledOnToggle)?.(event, {
+              id,
+              isExpanded: !expanded,
+              label,
+              value,
+            });
           }
           setExpanded(!expanded);
         }

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -150,17 +150,12 @@
   }
 
   .#{$prefix}--btn--icon-only {
+    align-items: center;
     justify-content: center;
     padding: 0;
     block-size: layout.size('height');
     inline-size: layout.size('height');
-    // -1px to compensate for border width
-    padding-block-start: min(
-      calc(
-        (layout.size('height') - convert.to-rem(16px)) / 2 - convert.to-rem(1px)
-      ),
-      var(--temp-padding-block-max)
-    );
+    padding-block-start: 0;
 
     > :first-child {
       min-inline-size: convert.to-rem(16px);

--- a/packages/styles/scss/components/skeleton-styles/_ai-skeleton-styles.scss
+++ b/packages/styles/scss/components/skeleton-styles/_ai-skeleton-styles.scss
@@ -8,6 +8,7 @@
 @use '../../config' as *;
 @use '../../theme';
 @use '../../utilities/convert';
+@use '../../utilities/high-contrast-mode' as *;
 
 @keyframes ai-skeleton-animation {
   0% {
@@ -60,6 +61,22 @@
   //skeleton icon
   .#{$prefix}--skeleton__icon--ai {
     border-radius: convert.to-rem(2px);
+  }
+
+  //High Contrast Mode
+  //Ensure AI Skeleton is visible and animated in Windows HCM
+  @include high-contrast-mode {
+    .#{$prefix}--skeleton__text--ai,
+    .#{$prefix}--skeleton__placeholder--ai,
+    .#{$prefix}--skeleton__icon--ai {
+      background: CanvasText;
+    }
+
+    .#{$prefix}--skeleton__text--ai::before,
+    .#{$prefix}--skeleton__placeholder--ai::before,
+    .#{$prefix}--skeleton__icon--ai::before {
+      background: Canvas;
+    }
   }
 }
 

--- a/packages/styles/scss/utilities/_skeleton.scss
+++ b/packages/styles/scss/utilities/_skeleton.scss
@@ -8,6 +8,7 @@
 @use 'keyframes';
 @use '../theme' as *;
 @use '../config' as *;
+@use '../utilities/high-contrast-mode' as *;
 
 /// Skeleton loading animation
 /// @access public
@@ -43,6 +44,16 @@
       animation: none;
     }
   }
+
+  // High Contrast Mode support
+  @include high-contrast-mode {
+    background: CanvasText;
+
+    &::before {
+      background: Canvas;
+      forced-color-adjust: none;
+    }
+  }
 }
 
 /// Circular Skeleton loading animation
@@ -66,6 +77,17 @@
 
     @media (prefers-reduced-motion: reduce) {
       animation: none;
+    }
+  }
+
+  //High Contrast Mode
+  //Ensure Skeleton is visible and animated in Windows HCM
+  @include high-contrast-mode {
+    background: CanvasText;
+
+    &::before {
+      background: Canvas;
+      forced-color-adjust: none;
     }
   }
 }

--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -100,20 +100,23 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-button) {
+  .#{$prefix}--btn--icon-only {
+    align-items: center;
+    padding-block-start: 0;
+
+    &.#{$prefix}--btn--selected,
+    &.#{$prefix}--btn--expressive {
+      padding: $spacing-03;
+    }
+  }
+}
+
 :host(#{$prefix}-button[kind='ghost']) {
   .#{$prefix}--btn--ghost {
     &:hover,
     &:active {
       outline: none;
-    }
-
-    &.#{$prefix}--btn--icon-only {
-      padding-block-start: 0;
-
-      &.#{$prefix}--btn--selected,
-      &.#{$prefix}--btn--expressive {
-        padding: $spacing-03;
-      }
     }
 
     &:not(:focus) {

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -179,6 +179,7 @@ class CDSDropdown extends ValidityMixin(
           this._handleUserInitiatedToggle(false);
           break;
         case DROPDOWN_KEYBOARD_ACTION.NAVIGATING:
+          event.preventDefault();
           this._navigate(NAVIGATION_DIRECTION[key]);
           break;
         default:

--- a/packages/web-components/src/components/search/__tests__/search-test.js
+++ b/packages/web-components/src/components/search/__tests__/search-test.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/web-components/es/components/search/index.js';
+import { expect, fixture, html } from '@open-wc/testing';
+
+describe('cds-search', () => {
+  describe('renders as expected - Component API', () => {
+    it('should respect the autocomplete attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" autocomplete="test"></cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.attribute('autocomplete', 'test');
+    });
+
+    it('should support a custom class on the outermost element', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" class="custom-class"></cds-search>
+      `);
+
+      expect(el).to.have.class('custom-class');
+    });
+
+    it('should respect the close-button-label-text attribute', async () => {
+      const el = await fixture(html`
+        <cds-search
+          label-text="test-search"
+          close-button-label-text="clear"></cds-search>
+      `);
+
+      const closeButton =
+        el.shadowRoot?.querySelector('button[data-action="clear"]') ||
+        el.shadowRoot?.querySelector('button[aria-label="clear"]') ||
+        el.shadowRoot?.querySelector('button[title="clear"]');
+      expect(closeButton).to.exist;
+    });
+
+    it('should respect the disabled attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" disabled></cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.attribute('disabled');
+    });
+
+    it('should respect the label-text attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search"></cds-search>
+      `);
+
+      const label = el.shadowRoot?.querySelector('label');
+      expect(label?.textContent?.trim()).to.equal('test-search');
+    });
+
+    it('should call focus expand button on Escape when expanded', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" is-expanded> </cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      const expandButton =
+        el.shadowRoot?.querySelector('button[data-action="expand"]') ||
+        el.shadowRoot?.querySelector('button.cds--search-magnifier');
+
+      if (input && expandButton) {
+        input.focus();
+        const escapeEvent = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+        });
+        input.dispatchEvent(escapeEvent);
+        await el.updateComplete;
+
+        expect(document.activeElement).to.equal(expandButton);
+      }
+    });
+
+    it('should have tabbable button and untabbable input if expandable and not expanded', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" expandable> </cds-search>
+      `);
+
+      expect(el).to.have.attribute('expandable');
+      expect(el).to.not.have.attribute('expanded');
+    });
+
+    it('should have tabbable input and untabbable button if not expandable', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search"></cds-search>
+      `);
+
+      expect(el).to.not.have.attribute('expandable');
+    });
+
+    it('should respect the placeholder attribute', async () => {
+      const el = await fixture(html`
+        <cds-search
+          label-text="test-search"
+          placeholder="test-placeholder"></cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.attribute('placeholder', 'test-placeholder');
+    });
+
+    it('should set hasCustomIcon when a custom icon is provided', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search">
+          <svg slot="icon" data-testid="test-icon"></svg>
+        </cds-search>
+      `);
+
+      const customIcon = el.querySelector('svg[data-testid="test-icon"]');
+      expect(customIcon).to.exist;
+    });
+
+    it('should respect the role attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" role="combobox"></cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.attribute('role', 'combobox');
+    });
+
+    it('should respect the size attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" size="sm"></cds-search>
+      `);
+      expect(el).to.have.attribute('size', 'sm');
+    });
+
+    it('should respect the type attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" type="search"></cds-search>
+      `);
+
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.attribute('type', 'search');
+    });
+
+    it('should respect the value attribute', async () => {
+      const el = await fixture(html`
+        <cds-search label-text="test-search" value="test-value"></cds-search>
+      `);
+      const input = el.shadowRoot?.querySelector('input');
+      expect(input).to.have.property('value', 'test-value');
+    });
+  });
+});

--- a/packages/web-components/src/components/ui-shell/header-global-action.ts
+++ b/packages/web-components/src/components/ui-shell/header-global-action.ts
@@ -61,22 +61,37 @@ class CDSHeaderGlobalAction extends CDSButton {
 
   firstUpdated() {
     document.addEventListener('click', this._handleDocumentClick, true);
+    document.addEventListener('focusin', this._handleDocumentFocusIn, true);
   }
 
   disconnectedCallback() {
     document.removeEventListener('click', this._handleDocumentClick, true);
+    document.removeEventListener('focusin', this._handleDocumentFocusIn, true);
     super.disconnectedCallback();
   }
 
   private _handleDocumentClick = (event: MouseEvent) => {
-    const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
-    const target = event.composedPath()[0] as HTMLElement;
+    const path = event.composedPath();
+    this._handlePanelCloseIfFocusOutside(path);
+  };
 
-    if (panel && !this.contains(target) && !panel.contains(target)) {
+  private _handleDocumentFocusIn = (event: FocusEvent) => {
+    const path = event.composedPath();
+    this._handlePanelCloseIfFocusOutside(path);
+  };
+
+  private _handlePanelCloseIfFocusOutside(path: EventTarget[]) {
+    const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
+    const isInside = path.some(
+      (el) =>
+        el instanceof HTMLElement && (panel?.contains(el) || this.contains(el))
+    );
+
+    if (panel && !isInside) {
       panel.removeAttribute('expanded');
       this.active = false;
     }
-  };
+  }
 
   @HostListener('focusout')
   // @ts-ignore


### PR DESCRIPTION
Closes #19857

{{short description}}

### Changelog


**Changed**

- Added margin-block-start to header SCSS



#### Testing / Reviewing

- click on the header menu buttons


### Screenshort


<img width="1728" height="1094" alt="Screenshot 2025-07-25 at 3 19 01 PM" src="https://github.com/user-attachments/assets/66365105-ff88-49af-8586-77dc91071d21" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)



